### PR TITLE
fix a typo in AIC/BIC description in notebook-3b

### DIFF
--- a/3b_MultipleRegressionSupplement.ipynb
+++ b/3b_MultipleRegressionSupplement.ipynb
@@ -205,8 +205,9 @@
     "\n",
     "Commonly used model selection criteria which fall under this paradigm include the **Akaike information criterion** (AIC) and **Bayesian information criterion** (BIC) which penalize the log-likelihood penalty respectively with\n",
     "\n",
-    "$$p_{\\text{AIC}}=k\\\\\n",
-    "p_{\\text{BIC}} = \\frac{k}{2}\\log n$$"
+    "$$p_{\\text{AIC}} = 2 k$$ $$p_{\\text{BIC}} = k \\log n,$$ \n",
+    "\n",
+    "so $p_{\\text{BIC}} = \\frac{\\log n}{2} p_{\\text{AIC}} = k \\log n$. Here, $k$ is the model degrees of freedom and $n$ is the number of observations. "
    ]
   },
   {


### PR DESCRIPTION
The RHS expression in the original notebook appears to be the complexity penalty of the Minimum Description Length instead. 